### PR TITLE
docs: improve onboarding and technical docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,14 @@ Modern Contacts CRUD built with:
 
 ## Getting Started
 ```bash
-npm install
-npm run dev      # Development server
-npm run build    # Production build
-npm run preview  # Preview production build
+bun install
+bun run dev      # Development server
+bun run build    # Production build
+bun run preview  # Preview production build
 ```
+
+## Documentation
+
+- Product overview: `docs/overview.md`
+- Technical architecture: `docs/architecture.md`
+- Migration prompt (optional Nuxt -> Vite + React): `docs/migration-prompt.md`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,22 @@
+# Architecture
+
+## Stack
+
+- Nuxt 4
+- Vue 3 (Composition API)
+- TypeScript
+- Tailwind CSS 4
+- Pinia
+
+## Main Directories
+
+- `pages`: route pages
+- `components`: reusable UI
+- `stores`: global state and derived selectors
+- `composables`: shared logic hooks
+- `types`: DTO/domain typing
+- `shared`: constants/helpers
+
+## Data Strategy
+
+Current implementation relies on browser persistence (localStorage) and in-memory state hydration via Pinia.

--- a/docs/migration-prompt.md
+++ b/docs/migration-prompt.md
@@ -1,0 +1,3 @@
+# Prompt Ideal - simple-crud-vue
+
+"Migrate this contacts CRUD app from Nuxt/Vue to Vite + React + TypeScript + Tailwind + shadcn/ui while preserving feature parity: dashboard metrics, search, filters, sorting, favorites, import/export JSON, dark mode, table/card views, and responsive layout. Keep project-specific color identity and visual language; do not copy external palettes. Apply smooth but functional motion (staggered reveal, view transitions, interactive states). Deliver two pull requests: docs first, migration second. Include Vercel deployment adjustments if present and complete QA checklist for all CRUD and filter flows."

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,21 @@
+# Overview
+
+## Product
+
+SCV is a modern contacts CRUD application focused on productivity and clarity.
+
+## Core Features
+
+- contact create/read/update/delete
+- favorite contacts
+- dashboard metrics
+- search, filters, and sorting
+- table and card/grid views
+- import/export JSON
+- responsive design and dark mode
+
+## User Value
+
+- quick personal contact management
+- clear visual hierarchy for dense information
+- low friction flows for edit, filter, and export


### PR DESCRIPTION
## Summary
- update README to use bun commands and link docs
- add docs/overview.md and docs/architecture.md
- add docs/migration-prompt.md for optional framework migration

## Why
- improve project handoff and maintainability
- keep migration strategy documented and repeatable

## Validation
- docs-only change, no runtime behavior changes